### PR TITLE
Fixing a conditional that was creating the wrong Policy

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -191,7 +191,7 @@ data "aws_iam_policy_document" "concourse_worker_assume_ci_role_custom" {
 resource "aws_iam_policy" "concourse_worker_assume_ci_role" {
   name        = "${local.environment}-concourse-worker-assume-ci-role"
   description = "Allow Concourse Workers to assume the CI Role"
-  policy      = var.concourse_worker_conf.instance_iam_role == null ? data.aws_iam_policy_document.concourse_worker_assume_ci_role_custom.json : data.aws_iam_policy_document.concourse_worker_assume_ci_role_default.json
+  policy      = var.concourse_worker_conf.worker_assume_ci_roles == null ? data.aws_iam_policy_document.concourse_worker_assume_ci_role_default.json : data.aws_iam_policy_document.concourse_worker_assume_ci_role_custom.json
 }
 
 resource "aws_iam_role_policy_attachment" "concourse_worker_assume_ci_role" {


### PR DESCRIPTION
custom vs default. Also renamed SID for clarity.

Wrong Policy was being selected as the conditional was the wrong way around - as a result, we were passing {{null}} for the {{instance_iam_role}} in module instantiation, and it was choosing to create a Default Policy (with only the local Account's AWS Account Number in it) rather than a Custom Policy (which contains all AWS Accounts found in the {{locals.accounts}} map).

Signed-off-by: Benjamin Sherwood <benjamin.sherwood@ext.ons.gov.uk>