### PR TITLE
Update netstat command for Concourse liveness check

### DIFF
--- a/files/concourse_web/teams.sh
+++ b/files/concourse_web/teams.sh
@@ -9,7 +9,7 @@ mkdir -p $HOME/bin
 tar -xzf $fly_tarball -C $HOME/bin/
 
 echo `date +'%Y %b %d %H:%M:%S'` "Waiting for Concourse to start."
-while [[ "$(netstat -n | grep ${concourse_web_port} | wc -l)" -lt 1 ]]; do
+while [[ "$(netstat -pln | grep ${concourse_web_port} | grep LISTEN | wc -l)" -lt 1 ]]; do
   sleep 5
   ((i=i+1))
   if [[ $i -gt 200 ]]; then


### PR DESCRIPTION
Have noticed on the past few Concourse builds, `teams.sh` isn't working as desired. Checked the start up logs and found this;

```
Dec  9 15:15:39 x.x.x.x cloud-init: 2021 Dec 09 15:15:39 Concourse service is up and listening on TCP port 8080
Dec  9 15:15:39 x.x.x.x cloud-init: 2021 Dec 09 15:15:39 Creating Concourse teams
Dec  9 15:15:39 x.x.x.x cloud-init: logging in to team 'main'
Dec  9 15:15:39 x.x.x.x cloud-init: could not reach the Concourse server called aws-concourse:
Dec  9 15:15:39 x.x.x.x cloud-init: Get "http://127.0.0.1:8080/api/v1/info": dial tcp 127.0.0.1:8080: connect: connection refused
Dec  9 15:15:39 x.x.x.x cloud-init: is the targeted Concourse running? better go catch it lol
```

Have tested with the updates in the MR and have got it to run `teams.sh` to completion successfully.