### PR TITLE
allow EBS volume type, iops, and size to be set by user

### DIFF
--- a/concourse_web.tf
+++ b/concourse_web.tf
@@ -14,9 +14,9 @@ resource "aws_launch_template" "concourse_web" {
     ebs {
       delete_on_termination = true
       encrypted             = true
-      volume_type           = "io1"
-      iops                  = 2000
-      volume_size           = 40
+      volume_type           = var.concourse_web_conf.ebs_volume.type
+      iops                  = var.concourse_web_conf.ebs_volume.iops
+      volume_size           = var.concourse_web_conf.ebs_volume.size
     }
   }
 

--- a/concourse_worker.tf
+++ b/concourse_worker.tf
@@ -13,9 +13,9 @@ resource "aws_launch_template" "concourse_worker" {
     ebs {
       delete_on_termination = true
       encrypted             = true
-      volume_type           = "io1"
-      iops                  = 2000
-      volume_size           = 100
+      volume_type           = var.concourse_worker_conf.ebs_volume.type
+      iops                  = var.concourse_worker_conf.ebs_volume.iops
+      volume_size           = var.concourse_worker_conf.ebs_volume.size
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,11 @@ variable "concourse_web_conf" {
         time             = string
       })
     })
+    ebs_volume = object({
+      type = string
+      iops = number
+      size = number
+    })
   })
 
   default = {
@@ -80,6 +85,11 @@ variable "concourse_web_conf" {
         desired_capacity = 1
         time             = "0 7 * * 1-5"
       }
+    }
+    ebs_volume = {
+      type = "gp3"
+      iops = 3000
+      size = 40
     }
   }
 }
@@ -111,6 +121,11 @@ variable "concourse_worker_conf" {
         time             = string
       })
     })
+    ebs_volume = object({
+      type = string
+      iops = number
+      size = number
+    })
   })
   default = {
     instance_iam_role      = null
@@ -136,6 +151,11 @@ variable "concourse_worker_conf" {
         desired_capacity = 1
         time             = "0 7 * * 1-5"
       }
+    }
+    ebs_volume = {
+      type = "gp3"
+      iops = 3000
+      size = 100
     }
   }
 }


### PR DESCRIPTION
Add object for EBS volume requirements to both web and worker config variables. Set defaults to general purpose SSDs. This changes the variable structure so is a breaking change for anyone using those variables (which are typically used).

Signed-off-by: Daniel.Hill <daniel.hill@engineering.digital.dwp.gov.uk>