### PR TITLE
Replace deprecated SSM IAM policy

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -40,12 +40,12 @@ resource "aws_iam_role_policy_attachment" "concourse_worker_cloudwatch_logging" 
 }
 
 resource "aws_iam_role_policy_attachment" "concourse_web_ssm" {
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonSSMManagedInstanceCore"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
   role       = aws_iam_role.concourse_web.id
 }
 
 resource "aws_iam_role_policy_attachment" "concourse_worker_ssm" {
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonSSMManagedInstanceCore"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
   role       = var.concourse_worker_conf.instance_iam_role == null ? aws_iam_role.concourse_worker[0].id : var.concourse_worker_conf.instance_iam_role
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -40,12 +40,12 @@ resource "aws_iam_role_policy_attachment" "concourse_worker_cloudwatch_logging" 
 }
 
 resource "aws_iam_role_policy_attachment" "concourse_web_ssm" {
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonSSMManagedInstanceCore"
   role       = aws_iam_role.concourse_web.id
 }
 
 resource "aws_iam_role_policy_attachment" "concourse_worker_ssm" {
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonSSMManagedInstanceCore"
   role       = var.concourse_worker_conf.instance_iam_role == null ? aws_iam_role.concourse_worker[0].id : var.concourse_worker_conf.instance_iam_role
 }
 


### PR DESCRIPTION
Replaced deprecated IAM policy `AmazonEC2RoleforSSM` in `iam.tf` with the `AmazonSSMManagedInstanceCore` policy as per this AWS blog: https://aws.amazon.com/blogs/mt/applying-managed-instance-policy-best-practices/
AWS don't give a date for when it will be deprecated (helpful as always), but thought it was wise to get a fix in early! Many thanks, Paul.